### PR TITLE
Adapt install_requires with native celery libraries and make rabbitmq as extra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 #
 
-FROM registry.dpi.inpe.br/brazildatacube/geo:0.3
+FROM python:3.8
 
 ADD . /app
 
 WORKDIR /app
 
-RUN pip3 install pip --upgrade && \
-    pip3 install wheel && \
-    pip3 install -e .
+RUN python -m pip install pip --upgrade && \
+    python -m pip install wheel && \
+    python -m pip install -e .[rabbitmq]

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -32,6 +32,8 @@ extensions = [
     # 'sphinx_tabs.tabs',
 ]
 
+autodoc_mock_imports = ['librabbitmq']
+
 # Paths that contain templates, relative to this directory.
 templates_path = ['_templates']
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ histogram_require = [
 extras_require = {
     'docs': docs_require,
     'tests': tests_require,
-    'histogram': histogram_require
+    'histogram': histogram_require,
+    'rabbitmq': [
+        'librabbitmq>=1.5.0',
+    ]
 }
 
 extras_require['all'] = [ req for exts, reqs in extras_require.items() for req in reqs ]
@@ -49,7 +52,7 @@ setup_requires = []
 
 install_requires = [
     'bdc-catalog @ git+git://github.com/brazil-data-cube/bdc-catalog.git@v0.8.1#egg=bdc-catalog',
-    'celery[librabbitmq]>=4.3.0,<5',
+    'celery>=4.3.0,<5',
     'Flask>=1.1.1,<2',
     'flask-redoc>=0.2.1',
     'marshmallow-sqlalchemy>=0.19.0,<1',


### PR DESCRIPTION
It fixes the readthedocs C library as defined [here](https://docs.readthedocs.io/en/stable/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules)